### PR TITLE
Added bootstrap-sass-official and font-awesome-sass to devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,5 +14,9 @@
     "**/.*",
     "bower_components"
   ],
-  "dependencies": {}
+  "dependencies": {},
+  "devDependencies": {
+    "bootstrap-sass-official": "3.3.3",
+    "font-awesome-sass": "4.3.1"
+  }
 }


### PR DESCRIPTION
This fixes #38 for when using gulp wiredep and the devDependencies option set to true (See https://github.com/taptapship/wiredep#how-it-works).