### PR TITLE
Use variables on .styled

### DIFF
--- a/awesome-bootstrap-checkbox.less
+++ b/awesome-bootstrap-checkbox.less
@@ -195,8 +195,8 @@
 input[type="checkbox"],
 input[type="radio"] {
   &.styled:checked + label:after {
-    font-family: 'FontAwesome';
-    content: "\f00c";
+    font-family: @font-family-icon;
+    content: @fa-var-check;
   }
   & .styled:checked + label {
     &::before {

--- a/awesome-bootstrap-checkbox.scss
+++ b/awesome-bootstrap-checkbox.scss
@@ -197,8 +197,8 @@ $font-family-icon: 'FontAwesome' !default;
 input[type="checkbox"],
 input[type="radio"] {
   &.styled:checked + label:after {
-    font-family: 'FontAwesome';
-    content: "\f00c";
+    font-family: $font-family-icon;
+    content: $fa-var-check;
   }
   & .styled:checked + label {
     &::before {


### PR DESCRIPTION
Fix issue not being able to override font-family and content when using the styled class.