### PR TITLE
Variable defaults, and a fix for the Opera styles 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ Just like the Sass setup, you'll have to `@import` the following library parts:
 @import "../bower_components/bootstrap/less/variables";
 @import "../bower_components/bootstrap/less/mixins";
 
-@import "../bower_components/Font-Awesome/less/variables";
-
 @import "../awesome-bootstrap-checkbox";
+
+@import "../bower_components/Font-Awesome/less/variables";
 ````
 
 Custom icon font

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 Awesome Bootstrap Checkbox
 ==========================
 
-Font Awesome Bootstrap Checkboxes &amp; Radios plugin. Pure css way to make inputs look prettier. **No javascript**!
+[Font Awesome][] [Bootstrap][] Checkboxes & Radios plugin. Pure CSS way to make inputs look prettier. **No Javascript!**
 
-**[Demo](http://flatlogic.github.io/awesome-bootstrap-checkbox/demo/)**
+**[Demo][]**
 
 Use
 ------------
 
-First just include **awesome-bootstrap-checkbox.css** somewhere in your html. Or **awesome-bootstrap-checkbox.scss** if you use sass.
-Next everything is based on code convention. Here is checkbox markup from Bootstrap site:
+First just include **awesome-bootstrap-checkbox.css** somewhere in your HTML, or add the equivalent files to your [Sass](#using-sass) / [Less](#using-less) configuration.
+Next, everything is based on code convention. Here is checkbox markup from Bootstrap site:
 
 ````html
 <form role="form">
@@ -85,15 +85,44 @@ You may use `checkbox-primary`, `checkbox-danger`, `radio-info`, etc to style ch
 
 `checkbox-single` and `radio-single` for inputs without label text.
 
-Glyphicons way (Opt-out Font Awesome)
+Using [Sass][]
+----------
+
+As per example in the `demo` folder, to use Font Awesome you'll have to `@import` the following library parts:
+
+````scss
+@import "../bower_components/bootstrap-sass-official/assets/stylesheets/bootstrap/variables";
+@import "../bower_components/bootstrap-sass-official/assets/stylesheets/bootstrap/mixins";
+
+@import "../bower_components/Font-Awesome/scss/variables";
+
+@import "../awesome-bootstrap-checkbox";
+````
+
+Adjust this to the path where your bootstrap and font-awesome files are located.
+
+Using [Less][]
+----------
+
+Just like the Sass setup, you'll have to `@import` the following library parts:
+
+````less
+@import "../bower_components/bootstrap/less/variables";
+@import "../bower_components/bootstrap/less/mixins";
+
+@import "../bower_components/Font-Awesome/less/variables";
+
+@import "../awesome-bootstrap-checkbox";
+````
+
+Custom icon font
 ------------
 
-If you want to use glyphicons instead of font-awesome then override `.checkbox` class:
-````css
-.checkbox input[type=checkbox]:checked + label:after {
-    font-family: 'Glyphicons Halflings';
-    content: "\e013";
-}
+If you want to use another icon font instead of Font Awesome, such as [Glyphicons][], override the default variables:
+````scss
+$font-family-icon: 'Glyphicons Halflings';
+$check-icon: "\e013";
+
 .checkbox label:after {
     padding-left: 4px;
     padding-top: 2px;
@@ -101,21 +130,42 @@ If you want to use glyphicons instead of font-awesome then override `.checkbox` 
 }
 ````
 
-Using SASS
-----------
+or for Less:
+````less
+@font-family-icon: 'Glyphicons Halflings';
+@check-icon: "\e013";
 
-As per example in the `demo` folder, to use these **awesome** you'll have to `@import` the following library parts:
-
-````scss
-@import "../bootstrap/bootstrap/variables";
-@import "../bootstrap/bootstrap/mixins";
-
-@import "../font-awesome/variables";
+// Same styles as the Sass example...
 ````
 
-Adjust this to the path where your bootstrap and font-awesome files are located.
+Or for plain CSS, override the `.checkbox` class (and `.styled` class for Opera):
+````css
+input[type="checkbox"].styled:checked + label:after,
+input[type="radio"].styled:checked + label:after,
+.checkbox input[type=checkbox]:checked + label:after {
+    font-family: 'Glyphicons Halflings';
+    content: "\e013";
+}
+
+input[type="checkbox"].styled:checked label:after,
+input[type="radio"].styled:checked label:after,
+.checkbox label:after {
+    padding-left: 4px;
+    padding-top: 2px;
+    font-size: 9px;
+}
+````
 
 Credits
 ------------
 
-Based on [Official Bootstrap Sass port](https://github.com/twbs/bootstrap-sass) and awesome [Font Awesome](https://github.com/FortAwesome/Font-Awesome).
+Based on the [Official Bootstrap Sass port][Bootstrap Sass] and the awesome [Font Awesome][].
+
+
+[Demo]: http://flatlogic.github.io/awesome-bootstrap-checkbox/demo/
+[Bootstrap]: http://getbootstrap.com/
+[Bootstrap Sass]: https://github.com/twbs/bootstrap-sass
+[Font Awesome]: https://github.com/FortAwesome/Font-Awesome
+[Glyphicons]: http://getbootstrap.com/components/#glyphicons
+[Sass]: http://sass-lang.com/
+[Less]: http://lesscss.org/

--- a/awesome-bootstrap-checkbox.less
+++ b/awesome-bootstrap-checkbox.less
@@ -3,6 +3,8 @@
 // --------------------------------------------------
 
 @font-family-icon: 'FontAwesome';
+@fa-var-check: "\f00c";
+@check-icon: @fa-var-check;
 
 .checkbox-variant(@parent, @color) {
   .@{parent} input[type="checkbox"]:checked + label,
@@ -67,7 +69,7 @@
 
     &:checked + label::after{
       font-family: @font-family-icon;
-      content: @fa-var-check;
+      content: @check-icon;
     }
 
     &:disabled + label{
@@ -196,7 +198,7 @@ input[type="checkbox"],
 input[type="radio"] {
   &.styled:checked + label:after {
     font-family: @font-family-icon;
-    content: @fa-var-check;
+    content: @check-icon;
   }
   & .styled:checked + label {
     &::before {

--- a/awesome-bootstrap-checkbox.less
+++ b/awesome-bootstrap-checkbox.less
@@ -195,8 +195,8 @@
 input[type="checkbox"],
 input[type="radio"] {
   &.styled:checked + label:after {
-    font-family: 'FontAwesome';
-    content: "\f00c";
+    font-family: @font-family-icon;
+    content: @fa-var-check;
   }
   & .styled:checked + label {
     &::before {

--- a/awesome-bootstrap-checkbox.scss
+++ b/awesome-bootstrap-checkbox.scss
@@ -197,8 +197,8 @@ $font-family-icon: 'FontAwesome' !default;
 input[type="checkbox"],
 input[type="radio"] {
   &.styled:checked + label:after {
-    font-family: 'FontAwesome';
-    content: "\f00c";
+    font-family: $font-family-icon;
+    content: $fa-var-check;
   }
   & .styled:checked + label {
     &::before {

--- a/awesome-bootstrap-checkbox.scss
+++ b/awesome-bootstrap-checkbox.scss
@@ -4,6 +4,8 @@
 
 
 $font-family-icon: 'FontAwesome' !default;
+$fa-var-check: "\f00c" !default;
+$check-icon: $fa-var-check !default;
 
 @mixin checkbox-variant($parent, $color) {
   #{$parent} input[type="checkbox"]:checked + label,
@@ -68,7 +70,7 @@ $font-family-icon: 'FontAwesome' !default;
 
     &:checked + label::after{
       font-family: $font-family-icon;
-      content: $fa-var-check;
+      content: $check-icon;
     }
 
     &:disabled + label{
@@ -198,7 +200,7 @@ input[type="checkbox"],
 input[type="radio"] {
   &.styled:checked + label:after {
     font-family: $font-family-icon;
-    content: $fa-var-check;
+    content: $check-icon;
   }
   & .styled:checked + label {
     &::before {

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "awesome-bootstrap-checkbox.css",
     "awesome-bootstrap-checkbox.scss"
   ],
-  "version": "0.3.5",
+  "version": "0.3.7",
   "homepage": "https://github.com/flatlogic/awesome-bootstrap-checkbox",
   "authors": [
     "okendoken flatlogic.com"

--- a/demo/build.less
+++ b/demo/build.less
@@ -1,6 +1,6 @@
 @import "../bower_components/bootstrap/less/variables";
 @import "../bower_components/bootstrap/less/mixins";
 
-@import "../bower_components/Font-Awesome/less/variables";
-
 @import "../awesome-bootstrap-checkbox";
+
+@import "../bower_components/Font-Awesome/less/variables";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-bootstrap-checkbox",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Font Awesome Bootstrap Checkboxes & Radios. Pure css way to make inputs look prettier.",
   "main": "awesome-bootstrap-checkbox.css",
   "scripts": {


### PR DESCRIPTION
An extension of @olyckne's pull request #53.

- Default `$fa-var-check` to `\f00c` if FA's variables aren't imported.
- A new `$check-icon` variable that defaults to `$fa-var-check`, so any custom font icon can be used without conflicting with FA's `$fa-var-check` variable.

- Changes to `README.md`:
    - Updated the outdated Sass example.
    - Added a section for Less.
    - Updated the Glyphicon CSS example.
    - Added links and other small text changes.