### PR TITLE
Add support for input tags inside label tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ Next, everything is based on code convention. Here is checkbox markup from Boots
 ````
 
 We have to alter it a bit:
+
+````html
+<form role="form">
+  ...
+  <div class="checkbox">
+    <label>
+      <input type="checkbox">
+      <span>Check me out</span>
+    </label>
+  </div>
+  ...
+</form>
+````
+
+Or, use an alternative form:
+
 ````html
 <form role="form">
   ...
@@ -43,7 +59,7 @@ We have to alter it a bit:
   ...
 </form>
 ````
-That's it. It will work. But it **will not** work if you nest input inside label or put label before input.
+That's it. It will work.
 
 If you want to enable **Opera 12** and earlier support  just add class `styled` to `input` element:
 ````html
@@ -63,7 +79,29 @@ Browser support
 Radios
 ------------
 
-It's the same for radios. Markup has to be the following:
+It's the same for radios. Markup has to be one of the following:
+
+````html
+<form role="form">
+  ...
+  <div class="radio">
+    <label>
+      <input type="radio" value="option1">
+      <span>One</span>
+    </label>
+  </div>
+  <div class="radio">
+    <label>
+      <input type="radio" value="option2">
+      <span>Two</span>
+    </label>
+  </div>
+  ...
+</form>
+````
+
+Or:
+
 ````html
 <form role="form">
   ...

--- a/awesome-bootstrap-checkbox.css
+++ b/awesome-bootstrap-checkbox.css
@@ -17,12 +17,12 @@
   height: 17px;
   left: 0;
   margin-left: -20px;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   border-radius: 3px;
   background-color: #fff;
-  -webkit-transition: "border 0.15s ease-in-out, color 0.15s ease-in-out";
-  -o-transition: "border 0.15s ease-in-out, color 0.15s ease-in-out";
-  transition: "border 0.15s ease-in-out, color 0.15s ease-in-out";
+  -webkit-transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
+  -o-transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
+  transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
 }
 .checkbox label::after,
 .checkbox label > span::after {
@@ -262,7 +262,7 @@
   height: 17px;
   left: 0;
   margin-left: -20px;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   border-radius: 50%;
   background-color: #fff;
   -webkit-transition: border 0.15s ease-in-out;

--- a/awesome-bootstrap-checkbox.css
+++ b/awesome-bootstrap-checkbox.css
@@ -1,13 +1,15 @@
 .checkbox {
   padding-left: 20px;
 }
-.checkbox label {
+.checkbox label,
+.checkbox label > span {
   display: inline-block;
   vertical-align: middle;
   position: relative;
   padding-left: 5px;
 }
-.checkbox label::before {
+.checkbox label::before,
+.checkbox label > span::before {
   content: "";
   display: inline-block;
   position: absolute;
@@ -15,14 +17,15 @@
   height: 17px;
   left: 0;
   margin-left: -20px;
-  border: 1px solid #cccccc;
+  border: 1px solid #ccc;
   border-radius: 3px;
   background-color: #fff;
-  -webkit-transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
-  -o-transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
-  transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
+  -webkit-transition: "border 0.15s ease-in-out, color 0.15s ease-in-out";
+  -o-transition: "border 0.15s ease-in-out, color 0.15s ease-in-out";
+  transition: "border 0.15s ease-in-out, color 0.15s ease-in-out";
 }
-.checkbox label::after {
+.checkbox label::after,
+.checkbox label > span::after {
   display: inline-block;
   position: absolute;
   width: 16px;
@@ -36,25 +39,45 @@
   color: #555555;
 }
 .checkbox input[type="checkbox"],
-.checkbox input[type="radio"] {
+.checkbox input[type="radio"],
+.checkbox label > input[type="checkbox"],
+.checkbox label > input[type="radio"] {
   opacity: 0;
   z-index: 1;
 }
 .checkbox input[type="checkbox"]:focus + label::before,
-.checkbox input[type="radio"]:focus + label::before {
+.checkbox input[type="radio"]:focus + label::before,
+.checkbox label > input[type="checkbox"]:focus + label::before,
+.checkbox label > input[type="radio"]:focus + label::before,
+.checkbox input[type="checkbox"]:focus + span::before,
+.checkbox input[type="radio"]:focus + span::before,
+.checkbox label > input[type="checkbox"]:focus + span::before,
+.checkbox label > input[type="radio"]:focus + span::before {
   outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
 .checkbox input[type="checkbox"]:checked + label::after,
-.checkbox input[type="radio"]:checked + label::after {
-  font-family: "FontAwesome";
+.checkbox input[type="radio"]:checked + label::after,
+.checkbox label > input[type="checkbox"]:checked + label::after,
+.checkbox label > input[type="radio"]:checked + label::after,
+.checkbox input[type="checkbox"]:checked + span::after,
+.checkbox input[type="radio"]:checked + span::after,
+.checkbox label > input[type="checkbox"]:checked + span::after,
+.checkbox label > input[type="radio"]:checked + span::after {
+  font-family: 'FontAwesome';
   content: "\f00c";
 }
 .checkbox input[type="checkbox"]:indeterminate + label::after,
-.checkbox input[type="radio"]:indeterminate + label::after {
+.checkbox input[type="radio"]:indeterminate + label::after,
+.checkbox label > input[type="checkbox"]:indeterminate + label::after,
+.checkbox label > input[type="radio"]:indeterminate + label::after,
+.checkbox input[type="checkbox"]:indeterminate + span::after,
+.checkbox input[type="radio"]:indeterminate + span::after,
+.checkbox label > input[type="checkbox"]:indeterminate + span::after,
+.checkbox label > input[type="radio"]:indeterminate + span::after {
   display: block;
-  content: "";
+  content: " ";
   width: 10px;
   height: 3px;
   background-color: #555555;
@@ -63,136 +86,175 @@
   margin-top: 7px;
 }
 .checkbox input[type="checkbox"]:disabled + label,
-.checkbox input[type="radio"]:disabled + label {
+.checkbox input[type="radio"]:disabled + label,
+.checkbox label > input[type="checkbox"]:disabled + label,
+.checkbox label > input[type="radio"]:disabled + label,
+.checkbox input[type="checkbox"]:disabled + span,
+.checkbox input[type="radio"]:disabled + span,
+.checkbox label > input[type="checkbox"]:disabled + span,
+.checkbox label > input[type="radio"]:disabled + span {
   opacity: 0.65;
 }
 .checkbox input[type="checkbox"]:disabled + label::before,
-.checkbox input[type="radio"]:disabled + label::before {
+.checkbox input[type="radio"]:disabled + label::before,
+.checkbox label > input[type="checkbox"]:disabled + label::before,
+.checkbox label > input[type="radio"]:disabled + label::before,
+.checkbox input[type="checkbox"]:disabled + span::before,
+.checkbox input[type="radio"]:disabled + span::before,
+.checkbox label > input[type="checkbox"]:disabled + span::before,
+.checkbox label > input[type="radio"]:disabled + span::before {
   background-color: #eeeeee;
   cursor: not-allowed;
 }
-.checkbox.checkbox-circle label::before {
+.checkbox.checkbox-circle label::before,
+.checkbox.checkbox-circle span::before {
   border-radius: 50%;
 }
 .checkbox.checkbox-inline {
   margin-top: 0;
 }
-
 .checkbox-primary input[type="checkbox"]:checked + label::before,
-.checkbox-primary input[type="radio"]:checked + label::before {
+.checkbox-primary input[type="radio"]:checked + label::before,
+.checkbox-primary input[type="checkbox"]:checked + span::before,
+.checkbox-primary input[type="radio"]:checked + span::before {
   background-color: #337ab7;
   border-color: #337ab7;
 }
 .checkbox-primary input[type="checkbox"]:checked + label::after,
-.checkbox-primary input[type="radio"]:checked + label::after {
+.checkbox-primary input[type="radio"]:checked + label::after,
+.checkbox-primary input[type="checkbox"]:checked + span::after,
+.checkbox-primary input[type="radio"]:checked + span::after {
   color: #fff;
 }
-
 .checkbox-danger input[type="checkbox"]:checked + label::before,
-.checkbox-danger input[type="radio"]:checked + label::before {
+.checkbox-danger input[type="radio"]:checked + label::before,
+.checkbox-danger input[type="checkbox"]:checked + span::before,
+.checkbox-danger input[type="radio"]:checked + span::before {
   background-color: #d9534f;
   border-color: #d9534f;
 }
 .checkbox-danger input[type="checkbox"]:checked + label::after,
-.checkbox-danger input[type="radio"]:checked + label::after {
+.checkbox-danger input[type="radio"]:checked + label::after,
+.checkbox-danger input[type="checkbox"]:checked + span::after,
+.checkbox-danger input[type="radio"]:checked + span::after {
   color: #fff;
 }
-
 .checkbox-info input[type="checkbox"]:checked + label::before,
-.checkbox-info input[type="radio"]:checked + label::before {
+.checkbox-info input[type="radio"]:checked + label::before,
+.checkbox-info input[type="checkbox"]:checked + span::before,
+.checkbox-info input[type="radio"]:checked + span::before {
   background-color: #5bc0de;
   border-color: #5bc0de;
 }
 .checkbox-info input[type="checkbox"]:checked + label::after,
-.checkbox-info input[type="radio"]:checked + label::after {
+.checkbox-info input[type="radio"]:checked + label::after,
+.checkbox-info input[type="checkbox"]:checked + span::after,
+.checkbox-info input[type="radio"]:checked + span::after {
   color: #fff;
 }
-
 .checkbox-warning input[type="checkbox"]:checked + label::before,
-.checkbox-warning input[type="radio"]:checked + label::before {
+.checkbox-warning input[type="radio"]:checked + label::before,
+.checkbox-warning input[type="checkbox"]:checked + span::before,
+.checkbox-warning input[type="radio"]:checked + span::before {
   background-color: #f0ad4e;
   border-color: #f0ad4e;
 }
 .checkbox-warning input[type="checkbox"]:checked + label::after,
-.checkbox-warning input[type="radio"]:checked + label::after {
+.checkbox-warning input[type="radio"]:checked + label::after,
+.checkbox-warning input[type="checkbox"]:checked + span::after,
+.checkbox-warning input[type="radio"]:checked + span::after {
   color: #fff;
 }
-
 .checkbox-success input[type="checkbox"]:checked + label::before,
-.checkbox-success input[type="radio"]:checked + label::before {
+.checkbox-success input[type="radio"]:checked + label::before,
+.checkbox-success input[type="checkbox"]:checked + span::before,
+.checkbox-success input[type="radio"]:checked + span::before {
   background-color: #5cb85c;
   border-color: #5cb85c;
 }
 .checkbox-success input[type="checkbox"]:checked + label::after,
-.checkbox-success input[type="radio"]:checked + label::after {
+.checkbox-success input[type="radio"]:checked + label::after,
+.checkbox-success input[type="checkbox"]:checked + span::after,
+.checkbox-success input[type="radio"]:checked + span::after {
   color: #fff;
 }
-
 .checkbox-primary input[type="checkbox"]:indeterminate + label::before,
-.checkbox-primary input[type="radio"]:indeterminate + label::before {
+.checkbox-primary input[type="radio"]:indeterminate + label::before,
+.checkbox-primary input[type="checkbox"]:indeterminate + span::before,
+.checkbox-primary input[type="radio"]:indeterminate + span::before {
   background-color: #337ab7;
   border-color: #337ab7;
 }
-
 .checkbox-primary input[type="checkbox"]:indeterminate + label::after,
-.checkbox-primary input[type="radio"]:indeterminate + label::after {
+.checkbox-primary input[type="radio"]:indeterminate + label::after,
+.checkbox-primary input[type="checkbox"]:indeterminate + span::after,
+.checkbox-primary input[type="radio"]:indeterminate + span::after {
   background-color: #fff;
 }
-
 .checkbox-danger input[type="checkbox"]:indeterminate + label::before,
-.checkbox-danger input[type="radio"]:indeterminate + label::before {
+.checkbox-danger input[type="radio"]:indeterminate + label::before,
+.checkbox-danger input[type="checkbox"]:indeterminate + span::before,
+.checkbox-danger input[type="radio"]:indeterminate + span::before {
   background-color: #d9534f;
   border-color: #d9534f;
 }
-
 .checkbox-danger input[type="checkbox"]:indeterminate + label::after,
-.checkbox-danger input[type="radio"]:indeterminate + label::after {
+.checkbox-danger input[type="radio"]:indeterminate + label::after,
+.checkbox-danger input[type="checkbox"]:indeterminate + span::after,
+.checkbox-danger input[type="radio"]:indeterminate + span::after {
   background-color: #fff;
 }
-
 .checkbox-info input[type="checkbox"]:indeterminate + label::before,
-.checkbox-info input[type="radio"]:indeterminate + label::before {
+.checkbox-info input[type="radio"]:indeterminate + label::before,
+.checkbox-info input[type="checkbox"]:indeterminate + span::before,
+.checkbox-info input[type="radio"]:indeterminate + span::before {
   background-color: #5bc0de;
   border-color: #5bc0de;
 }
-
 .checkbox-info input[type="checkbox"]:indeterminate + label::after,
-.checkbox-info input[type="radio"]:indeterminate + label::after {
+.checkbox-info input[type="radio"]:indeterminate + label::after,
+.checkbox-info input[type="checkbox"]:indeterminate + span::after,
+.checkbox-info input[type="radio"]:indeterminate + span::after {
   background-color: #fff;
 }
-
 .checkbox-warning input[type="checkbox"]:indeterminate + label::before,
-.checkbox-warning input[type="radio"]:indeterminate + label::before {
+.checkbox-warning input[type="radio"]:indeterminate + label::before,
+.checkbox-warning input[type="checkbox"]:indeterminate + span::before,
+.checkbox-warning input[type="radio"]:indeterminate + span::before {
   background-color: #f0ad4e;
   border-color: #f0ad4e;
 }
-
 .checkbox-warning input[type="checkbox"]:indeterminate + label::after,
-.checkbox-warning input[type="radio"]:indeterminate + label::after {
+.checkbox-warning input[type="radio"]:indeterminate + label::after,
+.checkbox-warning input[type="checkbox"]:indeterminate + span::after,
+.checkbox-warning input[type="radio"]:indeterminate + span::after {
   background-color: #fff;
 }
-
 .checkbox-success input[type="checkbox"]:indeterminate + label::before,
-.checkbox-success input[type="radio"]:indeterminate + label::before {
+.checkbox-success input[type="radio"]:indeterminate + label::before,
+.checkbox-success input[type="checkbox"]:indeterminate + span::before,
+.checkbox-success input[type="radio"]:indeterminate + span::before {
   background-color: #5cb85c;
   border-color: #5cb85c;
 }
-
 .checkbox-success input[type="checkbox"]:indeterminate + label::after,
-.checkbox-success input[type="radio"]:indeterminate + label::after {
+.checkbox-success input[type="radio"]:indeterminate + label::after,
+.checkbox-success input[type="checkbox"]:indeterminate + span::after,
+.checkbox-success input[type="radio"]:indeterminate + span::after {
   background-color: #fff;
 }
-
 .radio {
   padding-left: 20px;
 }
-.radio label {
+.radio label,
+.radio label > span {
   display: inline-block;
   vertical-align: middle;
   position: relative;
   padding-left: 5px;
 }
-.radio label::before {
+.radio label::before,
+.radio label > span::before {
   content: "";
   display: inline-block;
   position: absolute;
@@ -200,14 +262,15 @@
   height: 17px;
   left: 0;
   margin-left: -20px;
-  border: 1px solid #cccccc;
+  border: 1px solid #ccc;
   border-radius: 50%;
   background-color: #fff;
   -webkit-transition: border 0.15s ease-in-out;
   -o-transition: border 0.15s ease-in-out;
   transition: border 0.15s ease-in-out;
 }
-.radio label::after {
+.radio label::after,
+.radio label > span::after {
   display: inline-block;
   position: absolute;
   content: " ";
@@ -227,91 +290,119 @@
   -o-transition: -o-transform 0.1s cubic-bezier(0.8, -0.33, 0.2, 1.33);
   transition: transform 0.1s cubic-bezier(0.8, -0.33, 0.2, 1.33);
 }
-.radio input[type="radio"] {
+.radio input[type="radio"],
+.radio label > input[type="radio"] {
   opacity: 0;
   z-index: 1;
 }
-.radio input[type="radio"]:focus + label::before {
+.radio input[type="radio"]:focus + label::before,
+.radio label > input[type="radio"]:focus + label::before,
+.radio input[type="radio"]:focus + span::before,
+.radio label > input[type="radio"]:focus + span::before {
   outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-.radio input[type="radio"]:checked + label::after {
+.radio input[type="radio"]:checked + label::after,
+.radio label > input[type="radio"]:checked + label::after,
+.radio input[type="radio"]:checked + span::after,
+.radio label > input[type="radio"]:checked + span::after {
   -webkit-transform: scale(1, 1);
   -ms-transform: scale(1, 1);
   -o-transform: scale(1, 1);
   transform: scale(1, 1);
 }
-.radio input[type="radio"]:disabled + label {
+.radio input[type="radio"]:disabled + label,
+.radio label > input[type="radio"]:disabled + label,
+.radio input[type="radio"]:disabled + span,
+.radio label > input[type="radio"]:disabled + span {
   opacity: 0.65;
 }
-.radio input[type="radio"]:disabled + label::before {
+.radio input[type="radio"]:disabled + label::before,
+.radio label > input[type="radio"]:disabled + label::before,
+.radio input[type="radio"]:disabled + span::before,
+.radio label > input[type="radio"]:disabled + span::before {
   cursor: not-allowed;
 }
 .radio.radio-inline {
   margin-top: 0;
 }
-
-.radio-primary input[type="radio"] + label::after {
+.radio-primary input[type="radio"] + label::after,
+.radio-primary input[type="radio"] + span::after {
   background-color: #337ab7;
 }
-.radio-primary input[type="radio"]:checked + label::before {
+.radio-primary input[type="radio"]:checked + label::before,
+.radio-primary input[type="radio"]:checked + span::before {
   border-color: #337ab7;
 }
-.radio-primary input[type="radio"]:checked + label::after {
+.radio-primary input[type="radio"]:checked + label::after,
+.radio-primary input[type="radio"]:checked + span::after {
   background-color: #337ab7;
 }
-
-.radio-danger input[type="radio"] + label::after {
+.radio-danger input[type="radio"] + label::after,
+.radio-danger input[type="radio"] + span::after {
   background-color: #d9534f;
 }
-.radio-danger input[type="radio"]:checked + label::before {
+.radio-danger input[type="radio"]:checked + label::before,
+.radio-danger input[type="radio"]:checked + span::before {
   border-color: #d9534f;
 }
-.radio-danger input[type="radio"]:checked + label::after {
+.radio-danger input[type="radio"]:checked + label::after,
+.radio-danger input[type="radio"]:checked + span::after {
   background-color: #d9534f;
 }
-
-.radio-info input[type="radio"] + label::after {
+.radio-info input[type="radio"] + label::after,
+.radio-info input[type="radio"] + span::after {
   background-color: #5bc0de;
 }
-.radio-info input[type="radio"]:checked + label::before {
+.radio-info input[type="radio"]:checked + label::before,
+.radio-info input[type="radio"]:checked + span::before {
   border-color: #5bc0de;
 }
-.radio-info input[type="radio"]:checked + label::after {
+.radio-info input[type="radio"]:checked + label::after,
+.radio-info input[type="radio"]:checked + span::after {
   background-color: #5bc0de;
 }
-
-.radio-warning input[type="radio"] + label::after {
+.radio-warning input[type="radio"] + label::after,
+.radio-warning input[type="radio"] + span::after {
   background-color: #f0ad4e;
 }
-.radio-warning input[type="radio"]:checked + label::before {
+.radio-warning input[type="radio"]:checked + label::before,
+.radio-warning input[type="radio"]:checked + span::before {
   border-color: #f0ad4e;
 }
-.radio-warning input[type="radio"]:checked + label::after {
+.radio-warning input[type="radio"]:checked + label::after,
+.radio-warning input[type="radio"]:checked + span::after {
   background-color: #f0ad4e;
 }
-
-.radio-success input[type="radio"] + label::after {
+.radio-success input[type="radio"] + label::after,
+.radio-success input[type="radio"] + span::after {
   background-color: #5cb85c;
 }
-.radio-success input[type="radio"]:checked + label::before {
+.radio-success input[type="radio"]:checked + label::before,
+.radio-success input[type="radio"]:checked + span::before {
   border-color: #5cb85c;
 }
-.radio-success input[type="radio"]:checked + label::after {
+.radio-success input[type="radio"]:checked + label::after,
+.radio-success input[type="radio"]:checked + span::after {
   background-color: #5cb85c;
 }
-
 input[type="checkbox"].styled:checked + label:after,
-input[type="radio"].styled:checked + label:after {
+input[type="radio"].styled:checked + label:after,
+input[type="checkbox"].styled:checked + span:after,
+input[type="radio"].styled:checked + span:after {
   font-family: 'FontAwesome';
   content: "\f00c";
 }
 input[type="checkbox"] .styled:checked + label::before,
-input[type="radio"] .styled:checked + label::before {
+input[type="radio"] .styled:checked + label::before,
+input[type="checkbox"] .styled:checked + span::before,
+input[type="radio"] .styled:checked + span::before {
   color: #fff;
 }
 input[type="checkbox"] .styled:checked + label::after,
-input[type="radio"] .styled:checked + label::after {
+input[type="radio"] .styled:checked + label::after,
+input[type="checkbox"] .styled:checked + span::after,
+input[type="radio"] .styled:checked + span::after {
   color: #fff;
 }

--- a/awesome-bootstrap-checkbox.less
+++ b/awesome-bootstrap-checkbox.less
@@ -8,7 +8,9 @@
 
 .checkbox-variant(@parent, @color) {
   .@{parent} input[type="checkbox"]:checked + label,
-  .@{parent} input[type="radio"]:checked + label {
+  .@{parent} input[type="radio"]:checked + label,
+  .@{parent} input[type="checkbox"]:checked + span,
+  .@{parent} input[type="radio"]:checked + span {
     &::before {
       background-color: @color;
       border-color: @color;
@@ -21,7 +23,9 @@
 
 .checkbox-variant-indeterminate(@parent, @color) {
   .@{parent} input[type="checkbox"]:indeterminate + label,
-  .@{parent} input[type="radio"]:indeterminate + label {
+  .@{parent} input[type="radio"]:indeterminate + label,
+  .@{parent} input[type="checkbox"]:indeterminate + span,
+  .@{parent} input[type="radio"]:indeterminate + span {
     &::before {
       background-color: @color;
       border-color: @color;
@@ -33,16 +37,17 @@
 }
 
 
-.checkbox{
+.checkbox {
   padding-left: 20px;
 
-  label{
+  label,
+  label > span {
     display: inline-block;
     vertical-align: middle;
     position: relative;
     padding-left: 5px;
 
-    &::before{
+    &::before {
       content: "";
       display: inline-block;
       position: absolute;
@@ -53,10 +58,10 @@
       border: 1px solid @input-border;
       border-radius: 3px;
       background-color: #fff;
-      .transition(~"border 0.15s ease-in-out, color 0.15s ease-in-out");
+      .transition("border 0.15s ease-in-out, color 0.15s ease-in-out");
     }
 
-    &::after{
+    &::after {
       display: inline-block;
       position: absolute;
       width: 16px;
@@ -72,20 +77,25 @@
   }
 
   input[type="checkbox"],
-  input[type="radio"]{
+  input[type="radio"],
+  label > input[type="checkbox"],
+  label > input[type="radio"] {
     opacity: 0;
     z-index: 1;
 
-    &:focus + label::before{
+    &:focus + label::before,
+    &:focus + span::before {
       .tab-focus();
     }
 
-    &:checked + label::after{
+    &:checked + label::after,
+    &:checked + span::after {
       font-family: @font-family-icon;
       content: @check-icon;
     }
 
-    &:indeterminate + label::after{
+    &:indeterminate + label::after,
+    &:indeterminate + span::after {
       display: block;
       content: " ";
       width: 10px;
@@ -96,10 +106,11 @@
       margin-top: 7px;
     }
 
-    &:disabled + label{
+    &:disabled + label,
+    &:disabled + span {
       opacity: 0.65;
 
-      &::before{
+      &::before {
         background-color: @input-bg-disabled;
         cursor: not-allowed;
       }
@@ -107,11 +118,12 @@
 
   }
 
-  &.checkbox-circle label::before{
+  &.checkbox-circle label::before,
+  &.checkbox-circle span::before {
     border-radius: 50%;
   }
 
-  &.checkbox-inline{
+  &.checkbox-inline {
     margin-top: 0;
   }
 }
@@ -133,33 +145,36 @@
 // --------------------------------------------------
 
 .radio-variant(@parent, @color) {
-  .@{parent} input[type="radio"]{
-    & + label{
+  .@{parent} input[type="radio"] {
+    & + label,
+    & + span {
       &::after{
         background-color: @color;
       }
     }
-    &:checked + label{
+    &:checked + label,
+    &:checked + span {
       &::before {
         border-color: @color;
       }
-      &::after{
+      &::after {
         background-color: @color;
       }
     }
   }
 }
 
-.radio{
+.radio {
   padding-left: 20px;
 
-  label{
+  label,
+  label > span {
     display: inline-block;
     vertical-align: middle;
     position: relative;
     padding-left: 5px;
 
-    &::before{
+    &::before {
       content: "";
       display: inline-block;
       position: absolute;
@@ -173,7 +188,7 @@
       .transition(border 0.15s ease-in-out);
     }
 
-    &::after{
+    &::after {
       display: inline-block;
       position: absolute;
       content: " ";
@@ -191,29 +206,33 @@
     }
   }
 
-  input[type="radio"]{
+  input[type="radio"],
+  label > input[type="radio"] {
     opacity: 0;
     z-index: 1;
 
-    &:focus + label::before{
+    &:focus + label::before,
+    &:focus + span::before {
       .tab-focus();
     }
 
-    &:checked + label::after{
+    &:checked + label::after,
+    &:checked + span::after {
       .scale(1, 1);
     }
 
-    &:disabled + label{
+    &:disabled + label,
+    &:disabled + span {
       opacity: 0.65;
 
-      &::before{
+      &::before {
         cursor: not-allowed;
       }
     }
 
   }
 
-  &.radio-inline{
+  &.radio-inline {
     margin-top: 0;
   }
 }
@@ -226,11 +245,13 @@
 
 input[type="checkbox"],
 input[type="radio"] {
-  &.styled:checked + label:after {
+  &.styled:checked + label:after,
+  &.styled:checked + span:after {
     font-family: @font-family-icon;
     content: @check-icon;
   }
-  & .styled:checked + label {
+  & .styled:checked + label,
+  & .styled:checked + span {
     &::before {
       color: #fff;
     }

--- a/awesome-bootstrap-checkbox.less
+++ b/awesome-bootstrap-checkbox.less
@@ -58,7 +58,7 @@
       border: 1px solid @input-border;
       border-radius: 3px;
       background-color: #fff;
-      .transition("border 0.15s ease-in-out, color 0.15s ease-in-out");
+      .transition(~"border 0.15s ease-in-out, color 0.15s ease-in-out");
     }
 
     &::after {

--- a/awesome-bootstrap-checkbox.scss
+++ b/awesome-bootstrap-checkbox.scss
@@ -9,12 +9,14 @@ $check-icon: $fa-var-check !default;
 
 @mixin checkbox-variant($parent, $color) {
   #{$parent} input[type="checkbox"]:checked + label,
-  #{$parent} input[type="radio"]:checked + label {
+  #{$parent} input[type="radio"]:checked + label,
+  #{$parent} input[type="checkbox"]:checked + span,
+  #{$parent} input[type="radio"]:checked + span {
     &::before {
       background-color: $color;
       border-color: $color;
     }
-    &::after{
+    &::after {
       color: #fff;
     }
   }
@@ -22,12 +24,14 @@ $check-icon: $fa-var-check !default;
 
 @mixin checkbox-variant-indeterminate($parent, $color) {
   #{$parent} input[type="checkbox"]:indeterminate + label,
-  #{$parent} input[type="radio"]:indeterminate + label {
+  #{$parent} input[type="radio"]:indeterminate + label,
+  #{$parent} input[type="checkbox"]:indeterminate + span,
+  #{$parent} input[type="radio"]:indeterminate + span {
     &::before {
       background-color: $color;
       border-color: $color;
     }
-    &::after{
+    &::after {
       background-color: #fff;
     }
   }
@@ -35,16 +39,17 @@ $check-icon: $fa-var-check !default;
 
 
 
-.checkbox{
+.checkbox {
   padding-left: 20px;
 
-  label{
+  label,
+  label > span {
     display: inline-block;
     vertical-align: middle;
     position: relative;
     padding-left: 5px;
 
-    &::before{
+    &::before {
       content: "";
       display: inline-block;
       position: absolute;
@@ -58,7 +63,7 @@ $check-icon: $fa-var-check !default;
       @include transition(border 0.15s ease-in-out, color 0.15s ease-in-out);
     }
 
-    &::after{
+    &::after {
       display: inline-block;
       position: absolute;
       width: 16px;
@@ -74,20 +79,25 @@ $check-icon: $fa-var-check !default;
   }
 
   input[type="checkbox"],
-  input[type="radio"] {
+  input[type="radio"],
+  label > input[type="checkbox"],
+  label > input[type="radio"] {
     opacity: 0;
     z-index: 1;
 
-    &:focus + label::before{
+    &:focus + label::before,
+    &:focus + span::before {
       @include tab-focus();
     }
 
-    &:checked + label::after{
+    &:checked + label::after,
+    &:checked + span::after {
       font-family: $font-family-icon;
       content: $check-icon;
     }
 
-    &:indeterminate + label::after{
+    &:indeterminate + label::after,
+    &:indeterminate + span::after {
       display: block;
       content: "";
       width: 10px;
@@ -98,10 +108,11 @@ $check-icon: $fa-var-check !default;
       margin-top: 7px;
     }
 
-    &:disabled + label{
+    &:disabled + label,
+    &:disabled + span {
       opacity: 0.65;
 
-      &::before{
+      &::before {
         background-color: $input-bg-disabled;
         cursor: not-allowed;
       }
@@ -109,11 +120,12 @@ $check-icon: $fa-var-check !default;
 
   }
 
-  &.checkbox-circle label::before{
+  &.checkbox-circle label::before,
+  &.checkbox-circle span::before {
     border-radius: 50%;
   }
 
-  &.checkbox-inline{
+  &.checkbox-inline {
     margin-top: 0;
   }
 }
@@ -136,33 +148,36 @@ $check-icon: $fa-var-check !default;
 // --------------------------------------------------
 
 @mixin radio-variant($parent, $color) {
-  #{$parent} input[type="radio"]{
-    + label{
-      &::after{
+  #{$parent} input[type="radio"] {
+    + label,
+    + span {
+      &::after {
         background-color: $color;
       }
     }
-    &:checked + label{
+    &:checked + label,
+    &:checked + span {
       &::before {
         border-color: $color;
       }
-      &::after{
+      &::after {
         background-color: $color;
       }
     }
   }
 }
 
-.radio{
+.radio {
   padding-left: 20px;
 
-  label{
+  label,
+  label > span {
     display: inline-block;
     vertical-align: middle;
     position: relative;
     padding-left: 5px;
 
-    &::before{
+    &::before {
       content: "";
       display: inline-block;
       position: absolute;
@@ -176,7 +191,7 @@ $check-icon: $fa-var-check !default;
       @include transition(border 0.15s ease-in-out);
     }
 
-    &::after{
+    &::after {
       display: inline-block;
       position: absolute;
       content: " ";
@@ -194,29 +209,33 @@ $check-icon: $fa-var-check !default;
     }
   }
 
-  input[type="radio"]{
+  input[type="radio"],
+  label > input[type="radio"] {
     opacity: 0;
     z-index: 1;
 
-    &:focus + label::before{
+    &:focus + label::before,
+    &:focus + span::before {
       @include tab-focus();
     }
 
-    &:checked + label::after{
+    &:checked + label::after,
+    &:checked + span::after {
       @include scale(1, 1);
     }
 
-    &:disabled + label{
+    &:disabled + label,
+    &:disabled + span {
       opacity: 0.65;
 
-      &::before{
+      &::before {
         cursor: not-allowed;
       }
     }
 
   }
 
-  &.radio-inline{
+  &.radio-inline {
     margin-top: 0;
   }
 }
@@ -230,11 +249,13 @@ $check-icon: $fa-var-check !default;
 
 input[type="checkbox"],
 input[type="radio"] {
-  &.styled:checked + label:after {
+  &.styled:checked + label:after,
+  &.styled:checked + span:after {
     font-family: $font-family-icon;
     content: $check-icon;
   }
-  .styled:checked + label {
+  .styled:checked + label,
+  .styled:checked + span {
     &::before {
       color: #fff;
     }


### PR DESCRIPTION
Building on #72 by @enumag, I've added selectors for input tags that are inside the label tags, while still retaining support for the other method as well. The one caveat is that the actual label text needs to be inside span tags. I've updated the LESS, SCSS, and CSS files, as well as the README to reflect the new changes.
