### PR TITLE
Use ~ (general sibling) selector instead of + (adjacent sibling)

### DIFF
--- a/awesome-bootstrap-checkbox.css
+++ b/awesome-bootstrap-checkbox.css
@@ -40,19 +40,19 @@
   opacity: 0;
   z-index: 1;
 }
-.checkbox input[type="checkbox"]:focus + label::before,
-.checkbox input[type="radio"]:focus + label::before {
+.checkbox input[type="checkbox"]:focus ~ label::before,
+.checkbox input[type="radio"]:focus ~ label::before {
   outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-.checkbox input[type="checkbox"]:checked + label::after,
-.checkbox input[type="radio"]:checked + label::after {
+.checkbox input[type="checkbox"]:checked ~ label::after,
+.checkbox input[type="radio"]:checked ~ label::after {
   font-family: "FontAwesome";
   content: "\f00c";
 }
-.checkbox input[type="checkbox"]:indeterminate + label::after,
-.checkbox input[type="radio"]:indeterminate + label::after {
+.checkbox input[type="checkbox"]:indeterminate ~ label::after,
+.checkbox input[type="radio"]:indeterminate ~ label::after {
   display: block;
   content: "";
   width: 10px;
@@ -62,12 +62,12 @@
   margin-left: -16.5px;
   margin-top: 7px;
 }
-.checkbox input[type="checkbox"]:disabled + label,
-.checkbox input[type="radio"]:disabled + label {
+.checkbox input[type="checkbox"]:disabled ~ label,
+.checkbox input[type="radio"]:disabled ~ label {
   opacity: 0.65;
 }
-.checkbox input[type="checkbox"]:disabled + label::before,
-.checkbox input[type="radio"]:disabled + label::before {
+.checkbox input[type="checkbox"]:disabled ~ label::before,
+.checkbox input[type="radio"]:disabled ~ label::before {
   background-color: #eeeeee;
   cursor: not-allowed;
 }
@@ -78,108 +78,108 @@
   margin-top: 0;
 }
 
-.checkbox-primary input[type="checkbox"]:checked + label::before,
-.checkbox-primary input[type="radio"]:checked + label::before {
+.checkbox-primary input[type="checkbox"]:checked ~ label::before,
+.checkbox-primary input[type="radio"]:checked ~ label::before {
   background-color: #337ab7;
   border-color: #337ab7;
 }
-.checkbox-primary input[type="checkbox"]:checked + label::after,
-.checkbox-primary input[type="radio"]:checked + label::after {
+.checkbox-primary input[type="checkbox"]:checked ~ label::after,
+.checkbox-primary input[type="radio"]:checked ~ label::after {
   color: #fff;
 }
 
-.checkbox-danger input[type="checkbox"]:checked + label::before,
-.checkbox-danger input[type="radio"]:checked + label::before {
+.checkbox-danger input[type="checkbox"]:checked ~ label::before,
+.checkbox-danger input[type="radio"]:checked ~ label::before {
   background-color: #d9534f;
   border-color: #d9534f;
 }
-.checkbox-danger input[type="checkbox"]:checked + label::after,
-.checkbox-danger input[type="radio"]:checked + label::after {
+.checkbox-danger input[type="checkbox"]:checked ~ label::after,
+.checkbox-danger input[type="radio"]:checked ~ label::after {
   color: #fff;
 }
 
-.checkbox-info input[type="checkbox"]:checked + label::before,
-.checkbox-info input[type="radio"]:checked + label::before {
+.checkbox-info input[type="checkbox"]:checked ~ label::before,
+.checkbox-info input[type="radio"]:checked ~ label::before {
   background-color: #5bc0de;
   border-color: #5bc0de;
 }
-.checkbox-info input[type="checkbox"]:checked + label::after,
-.checkbox-info input[type="radio"]:checked + label::after {
+.checkbox-info input[type="checkbox"]:checked ~ label::after,
+.checkbox-info input[type="radio"]:checked ~ label::after {
   color: #fff;
 }
 
-.checkbox-warning input[type="checkbox"]:checked + label::before,
-.checkbox-warning input[type="radio"]:checked + label::before {
+.checkbox-warning input[type="checkbox"]:checked ~ label::before,
+.checkbox-warning input[type="radio"]:checked ~ label::before {
   background-color: #f0ad4e;
   border-color: #f0ad4e;
 }
-.checkbox-warning input[type="checkbox"]:checked + label::after,
-.checkbox-warning input[type="radio"]:checked + label::after {
+.checkbox-warning input[type="checkbox"]:checked ~ label::after,
+.checkbox-warning input[type="radio"]:checked ~ label::after {
   color: #fff;
 }
 
-.checkbox-success input[type="checkbox"]:checked + label::before,
-.checkbox-success input[type="radio"]:checked + label::before {
+.checkbox-success input[type="checkbox"]:checked ~ label::before,
+.checkbox-success input[type="radio"]:checked ~ label::before {
   background-color: #5cb85c;
   border-color: #5cb85c;
 }
-.checkbox-success input[type="checkbox"]:checked + label::after,
-.checkbox-success input[type="radio"]:checked + label::after {
+.checkbox-success input[type="checkbox"]:checked ~ label::after,
+.checkbox-success input[type="radio"]:checked ~ label::after {
   color: #fff;
 }
 
-.checkbox-primary input[type="checkbox"]:indeterminate + label::before,
-.checkbox-primary input[type="radio"]:indeterminate + label::before {
+.checkbox-primary input[type="checkbox"]:indeterminate ~ label::before,
+.checkbox-primary input[type="radio"]:indeterminate ~ label::before {
   background-color: #337ab7;
   border-color: #337ab7;
 }
 
-.checkbox-primary input[type="checkbox"]:indeterminate + label::after,
-.checkbox-primary input[type="radio"]:indeterminate + label::after {
+.checkbox-primary input[type="checkbox"]:indeterminate ~ label::after,
+.checkbox-primary input[type="radio"]:indeterminate ~ label::after {
   background-color: #fff;
 }
 
-.checkbox-danger input[type="checkbox"]:indeterminate + label::before,
-.checkbox-danger input[type="radio"]:indeterminate + label::before {
+.checkbox-danger input[type="checkbox"]:indeterminate ~ label::before,
+.checkbox-danger input[type="radio"]:indeterminate ~ label::before {
   background-color: #d9534f;
   border-color: #d9534f;
 }
 
-.checkbox-danger input[type="checkbox"]:indeterminate + label::after,
-.checkbox-danger input[type="radio"]:indeterminate + label::after {
+.checkbox-danger input[type="checkbox"]:indeterminate ~ label::after,
+.checkbox-danger input[type="radio"]:indeterminate ~ label::after {
   background-color: #fff;
 }
 
-.checkbox-info input[type="checkbox"]:indeterminate + label::before,
-.checkbox-info input[type="radio"]:indeterminate + label::before {
+.checkbox-info input[type="checkbox"]:indeterminate ~ label::before,
+.checkbox-info input[type="radio"]:indeterminate ~ label::before {
   background-color: #5bc0de;
   border-color: #5bc0de;
 }
 
-.checkbox-info input[type="checkbox"]:indeterminate + label::after,
-.checkbox-info input[type="radio"]:indeterminate + label::after {
+.checkbox-info input[type="checkbox"]:indeterminate ~ label::after,
+.checkbox-info input[type="radio"]:indeterminate ~ label::after {
   background-color: #fff;
 }
 
-.checkbox-warning input[type="checkbox"]:indeterminate + label::before,
-.checkbox-warning input[type="radio"]:indeterminate + label::before {
+.checkbox-warning input[type="checkbox"]:indeterminate ~ label::before,
+.checkbox-warning input[type="radio"]:indeterminate ~ label::before {
   background-color: #f0ad4e;
   border-color: #f0ad4e;
 }
 
-.checkbox-warning input[type="checkbox"]:indeterminate + label::after,
-.checkbox-warning input[type="radio"]:indeterminate + label::after {
+.checkbox-warning input[type="checkbox"]:indeterminate ~ label::after,
+.checkbox-warning input[type="radio"]:indeterminate ~ label::after {
   background-color: #fff;
 }
 
-.checkbox-success input[type="checkbox"]:indeterminate + label::before,
-.checkbox-success input[type="radio"]:indeterminate + label::before {
+.checkbox-success input[type="checkbox"]:indeterminate ~ label::before,
+.checkbox-success input[type="radio"]:indeterminate ~ label::before {
   background-color: #5cb85c;
   border-color: #5cb85c;
 }
 
-.checkbox-success input[type="checkbox"]:indeterminate + label::after,
-.checkbox-success input[type="radio"]:indeterminate + label::after {
+.checkbox-success input[type="checkbox"]:indeterminate ~ label::after,
+.checkbox-success input[type="radio"]:indeterminate ~ label::after {
   background-color: #fff;
 }
 
@@ -231,87 +231,87 @@
   opacity: 0;
   z-index: 1;
 }
-.radio input[type="radio"]:focus + label::before {
+.radio input[type="radio"]:focus ~ label::before {
   outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
-.radio input[type="radio"]:checked + label::after {
+.radio input[type="radio"]:checked ~ label::after {
   -webkit-transform: scale(1, 1);
   -ms-transform: scale(1, 1);
   -o-transform: scale(1, 1);
   transform: scale(1, 1);
 }
-.radio input[type="radio"]:disabled + label {
+.radio input[type="radio"]:disabled ~ label {
   opacity: 0.65;
 }
-.radio input[type="radio"]:disabled + label::before {
+.radio input[type="radio"]:disabled ~ label::before {
   cursor: not-allowed;
 }
 .radio.radio-inline {
   margin-top: 0;
 }
 
-.radio-primary input[type="radio"] + label::after {
+.radio-primary input[type="radio"] ~ label::after {
   background-color: #337ab7;
 }
-.radio-primary input[type="radio"]:checked + label::before {
+.radio-primary input[type="radio"]:checked ~ label::before {
   border-color: #337ab7;
 }
-.radio-primary input[type="radio"]:checked + label::after {
+.radio-primary input[type="radio"]:checked ~ label::after {
   background-color: #337ab7;
 }
 
-.radio-danger input[type="radio"] + label::after {
+.radio-danger input[type="radio"] ~ label::after {
   background-color: #d9534f;
 }
-.radio-danger input[type="radio"]:checked + label::before {
+.radio-danger input[type="radio"]:checked ~ label::before {
   border-color: #d9534f;
 }
-.radio-danger input[type="radio"]:checked + label::after {
+.radio-danger input[type="radio"]:checked ~ label::after {
   background-color: #d9534f;
 }
 
-.radio-info input[type="radio"] + label::after {
+.radio-info input[type="radio"] ~ label::after {
   background-color: #5bc0de;
 }
-.radio-info input[type="radio"]:checked + label::before {
+.radio-info input[type="radio"]:checked ~ label::before {
   border-color: #5bc0de;
 }
-.radio-info input[type="radio"]:checked + label::after {
+.radio-info input[type="radio"]:checked ~ label::after {
   background-color: #5bc0de;
 }
 
-.radio-warning input[type="radio"] + label::after {
+.radio-warning input[type="radio"] ~ label::after {
   background-color: #f0ad4e;
 }
-.radio-warning input[type="radio"]:checked + label::before {
+.radio-warning input[type="radio"]:checked ~ label::before {
   border-color: #f0ad4e;
 }
-.radio-warning input[type="radio"]:checked + label::after {
+.radio-warning input[type="radio"]:checked ~ label::after {
   background-color: #f0ad4e;
 }
 
-.radio-success input[type="radio"] + label::after {
+.radio-success input[type="radio"] ~ label::after {
   background-color: #5cb85c;
 }
-.radio-success input[type="radio"]:checked + label::before {
+.radio-success input[type="radio"]:checked ~ label::before {
   border-color: #5cb85c;
 }
-.radio-success input[type="radio"]:checked + label::after {
+.radio-success input[type="radio"]:checked ~ label::after {
   background-color: #5cb85c;
 }
 
-input[type="checkbox"].styled:checked + label:after,
-input[type="radio"].styled:checked + label:after {
+input[type="checkbox"].styled:checked ~ label:after,
+input[type="radio"].styled:checked ~ label:after {
   font-family: 'FontAwesome';
   content: "\f00c";
 }
-input[type="checkbox"] .styled:checked + label::before,
-input[type="radio"] .styled:checked + label::before {
+input[type="checkbox"] .styled:checked ~ label::before,
+input[type="radio"] .styled:checked ~ label::before {
   color: #fff;
 }
-input[type="checkbox"] .styled:checked + label::after,
-input[type="radio"] .styled:checked + label::after {
+input[type="checkbox"] .styled:checked ~ label::after,
+input[type="radio"] .styled:checked ~ label::after {
   color: #fff;
 }

--- a/awesome-bootstrap-checkbox.less
+++ b/awesome-bootstrap-checkbox.less
@@ -7,8 +7,8 @@
 @check-icon: @fa-var-check;
 
 .checkbox-variant(@parent, @color) {
-  .@{parent} input[type="checkbox"]:checked + label,
-  .@{parent} input[type="radio"]:checked + label {
+  .@{parent} input[type="checkbox"]:checked ~ label,
+  .@{parent} input[type="radio"]:checked ~ label {
     &::before {
       background-color: @color;
       border-color: @color;
@@ -20,8 +20,8 @@
 }
 
 .checkbox-variant-indeterminate(@parent, @color) {
-  .@{parent} input[type="checkbox"]:indeterminate + label,
-  .@{parent} input[type="radio"]:indeterminate + label {
+  .@{parent} input[type="checkbox"]:indeterminate ~ label,
+  .@{parent} input[type="radio"]:indeterminate ~ label {
     &::before {
       background-color: @color;
       border-color: @color;
@@ -76,16 +76,16 @@
     opacity: 0;
     z-index: 1;
 
-    &:focus + label::before{
+    &:focus ~ label::before{
       .tab-focus();
     }
 
-    &:checked + label::after{
+    &:checked ~ label::after{
       font-family: @font-family-icon;
       content: @check-icon;
     }
 
-    &:indeterminate + label::after{
+    &:indeterminate ~ label::after{
       display: block;
       content: " ";
       width: 10px;
@@ -96,7 +96,7 @@
       margin-top: 7px;
     }
 
-    &:disabled + label{
+    &:disabled ~ label{
       opacity: 0.65;
 
       &::before{
@@ -134,12 +134,12 @@
 
 .radio-variant(@parent, @color) {
   .@{parent} input[type="radio"]{
-    & + label{
+    & ~ label{
       &::after{
         background-color: @color;
       }
     }
-    &:checked + label{
+    &:checked ~ label{
       &::before {
         border-color: @color;
       }
@@ -195,15 +195,15 @@
     opacity: 0;
     z-index: 1;
 
-    &:focus + label::before{
+    &:focus ~ label::before{
       .tab-focus();
     }
 
-    &:checked + label::after{
+    &:checked ~ label::after{
       .scale(1, 1);
     }
 
-    &:disabled + label{
+    &:disabled ~ label{
       opacity: 0.65;
 
       &::before{
@@ -226,11 +226,11 @@
 
 input[type="checkbox"],
 input[type="radio"] {
-  &.styled:checked + label:after {
+  &.styled:checked ~ label:after {
     font-family: @font-family-icon;
     content: @check-icon;
   }
-  & .styled:checked + label {
+  & .styled:checked ~ label {
     &::before {
       color: #fff;
     }

--- a/awesome-bootstrap-checkbox.scss
+++ b/awesome-bootstrap-checkbox.scss
@@ -8,8 +8,8 @@ $fa-var-check: "\f00c" !default;
 $check-icon: $fa-var-check !default;
 
 @mixin checkbox-variant($parent, $color) {
-  #{$parent} input[type="checkbox"]:checked + label,
-  #{$parent} input[type="radio"]:checked + label {
+  #{$parent} input[type="checkbox"]:checked ~ label,
+  #{$parent} input[type="radio"]:checked ~ label {
     &::before {
       background-color: $color;
       border-color: $color;
@@ -21,8 +21,8 @@ $check-icon: $fa-var-check !default;
 }
 
 @mixin checkbox-variant-indeterminate($parent, $color) {
-  #{$parent} input[type="checkbox"]:indeterminate + label,
-  #{$parent} input[type="radio"]:indeterminate + label {
+  #{$parent} input[type="checkbox"]:indeterminate ~ label,
+  #{$parent} input[type="radio"]:indeterminate ~ label {
     &::before {
       background-color: $color;
       border-color: $color;
@@ -78,16 +78,16 @@ $check-icon: $fa-var-check !default;
     opacity: 0;
     z-index: 1;
 
-    &:focus + label::before{
+    &:focus ~ label::before{
       @include tab-focus();
     }
 
-    &:checked + label::after{
+    &:checked ~ label::after{
       font-family: $font-family-icon;
       content: $check-icon;
     }
 
-    &:indeterminate + label::after{
+    &:indeterminate ~ label::after{
       display: block;
       content: "";
       width: 10px;
@@ -98,7 +98,7 @@ $check-icon: $fa-var-check !default;
       margin-top: 7px;
     }
 
-    &:disabled + label{
+    &:disabled ~ label{
       opacity: 0.65;
 
       &::before{
@@ -137,12 +137,12 @@ $check-icon: $fa-var-check !default;
 
 @mixin radio-variant($parent, $color) {
   #{$parent} input[type="radio"]{
-    + label{
+    ~ label{
       &::after{
         background-color: $color;
       }
     }
-    &:checked + label{
+    &:checked ~ label{
       &::before {
         border-color: $color;
       }
@@ -198,15 +198,15 @@ $check-icon: $fa-var-check !default;
     opacity: 0;
     z-index: 1;
 
-    &:focus + label::before{
+    &:focus ~ label::before{
       @include tab-focus();
     }
 
-    &:checked + label::after{
+    &:checked ~ label::after{
       @include scale(1, 1);
     }
 
-    &:disabled + label{
+    &:disabled ~ label{
       opacity: 0.65;
 
       &::before{
@@ -230,11 +230,11 @@ $check-icon: $fa-var-check !default;
 
 input[type="checkbox"],
 input[type="radio"] {
-  &.styled:checked + label:after {
+  &.styled:checked ~ label:after {
     font-family: $font-family-icon;
     content: $check-icon;
   }
-  .styled:checked + label {
+  .styled:checked ~ label {
     &::before {
       color: #fff;
     }


### PR DESCRIPTION
[A (long) while](https://github.com/flatlogic/awesome-bootstrap-checkbox/issues/1) ago there was discussion about replacing use of the adjacent sibling selector `+` with the general sibling selector `~`. This would be useful as it vastly increases compatibility with other frameworks which insert DOM objects around the input field (like an error).

The change was [held back](https://github.com/flatlogic/awesome-bootstrap-checkbox/issues/1#issuecomment-63086380) due to compatibility issues with mobile browsers at the time. Since then almost all mobile browsers have been brought up to speed and now provide support for the selector<sup>[1][2]</sup>. 
Could this change be made please?

[1]http://caniuse.com/#feat=css-sel3
[2]https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_selectors#Browser_compatibility
