### PR TITLE
Add line-height to checkbox label::after

### DIFF
--- a/awesome-bootstrap-checkbox.css
+++ b/awesome-bootstrap-checkbox.css
@@ -34,6 +34,7 @@
   padding-top: 1px;
   font-size: 11px;
   color: #555555;
+  line-height: 1.4;
 }
 .checkbox input[type="checkbox"],
 .checkbox input[type="radio"] {

--- a/awesome-bootstrap-checkbox.less
+++ b/awesome-bootstrap-checkbox.less
@@ -68,6 +68,7 @@
       padding-top: 1px;
       font-size: 11px;
       color: @input-color;
+      line-height: 1.4;
     }
   }
 

--- a/awesome-bootstrap-checkbox.scss
+++ b/awesome-bootstrap-checkbox.scss
@@ -70,6 +70,7 @@ $check-icon: $fa-var-check !default;
       padding-top: 1px;
       font-size: 11px;
       color: $input-color;
+      line-height: 1.4;
     }
   }
 


### PR DESCRIPTION
Some fonts need to get a different line-height, so that the font-awesome-icon inside the label::after is not positioned well.
This changes should fix that.